### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Swift用汎用クラス集
 ##Installation with CocoaPods
 
 ###Requirements
-requires iOS 8 & xCode7.2
+requires iOS 8 & Xcode7.2
 
 ###Podfile
 ```ruby


### PR DESCRIPTION

This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
